### PR TITLE
Fix buggy search

### DIFF
--- a/src/main/scala/apps/muntabot.scala
+++ b/src/main/scala/apps/muntabot.scala
@@ -9,7 +9,7 @@ object Muntabot extends App:
   val page = "#muntabot"
   val title = "muntabot"
   def setupUI(): Unit =
-    val containerElement = Document.setupContainer()
+    val containerElement = Document.appendDynamicContainer()
 
     Document.appendLinkToApp(
       containerElement,

--- a/src/main/scala/apps/rehearsal.scala
+++ b/src/main/scala/apps/rehearsal.scala
@@ -41,7 +41,7 @@ object Rehearsal extends App:
     document.getElementById("search-input").asInstanceOf[dom.html.Input]
 
   def setupCommonComponents(): dom.Element =
-    val containerElement = Document.setupContainer()
+    val containerElement = Document.appendDynamicContainer()
 
     Document.appendLinkToApp(containerElement, Muntabot, "Slumpa frågor")
 
@@ -86,7 +86,8 @@ object Rehearsal extends App:
     containerElement
 
   def searchView(): Unit =
-    val contentElement = Document.setupContainer("content", containerElement)
+    val contentElement =
+      Document.appendDynamicContainer("content", containerElement)
     Document.appendText(contentElement, "h2", "Sökresultat")
     for searchable <- searchables do
       if (searchable.toLowerCase.contains(searchTerm.toLowerCase)) then
@@ -97,7 +98,8 @@ object Rehearsal extends App:
         )
 
   def perCategory(): Unit =
-    val contentElement = Document.setupContainer("content", containerElement)
+    val contentElement =
+      Document.appendDynamicContainer("content", containerElement)
     Document.appendText(contentElement, "h2", "Per kategori")
 
     var number = 1
@@ -115,7 +117,8 @@ object Rehearsal extends App:
         number += 1
 
   def perWeek(): Unit =
-    val contentElement = Document.setupContainer("content", containerElement)
+    val contentElement =
+      Document.appendDynamicContainer("content", containerElement)
     var weeks = terms.map(_._1).distinct
     var number = 1
     for week <- weeks do

--- a/src/main/scala/apps/rehearsal.scala
+++ b/src/main/scala/apps/rehearsal.scala
@@ -90,7 +90,7 @@ object Rehearsal extends App:
   def searchView(): Unit =
     val contentElement =
       Document.appendDynamicContainer("content", containerElement)
-    Document.appendText(contentElement, "h2", "Sökresultat")
+    Document.appendText(contentElement, "h2", "Sökresultat:")
     for searchable <- searchables do
       if (searchable.toLowerCase.contains(searchTerm.toLowerCase)) then
         Document.appendText(

--- a/src/main/scala/apps/rehearsal.scala
+++ b/src/main/scala/apps/rehearsal.scala
@@ -31,11 +31,8 @@ object Rehearsal extends App:
     runSubpage()
 
   def runSubpage() =
-    if (searchTerm.length > 0) then searchView()
-    else
-      searchables.clear
-      if (currentSubpage == "week") then perWeek()
-      else if (currentSubpage == "category") then perCategory()
+    if (currentSubpage == "week") then perWeek()
+    else if (currentSubpage == "category") then perCategory()
 
   def searchInput =
     document.getElementById("search-input").asInstanceOf[dom.html.Input]
@@ -53,8 +50,13 @@ object Rehearsal extends App:
 
     Document.appendInput(containerElement, "Sök", "search-input") {
       searchTerm = searchInput.value
-      if (searchTerm.length > 0) then searchInput.value = searchTerm
-      searchView()
+      if searchTerm.length > 0 then
+        searchView()
+        searchInput.value = searchTerm
+      else
+        searchables.clear
+        runSubpage()
+
     }
 
     Document.appendButton(

--- a/src/main/scala/document.scala
+++ b/src/main/scala/document.scala
@@ -33,6 +33,7 @@ object Document:
     input.id = id
     input.placeholder = placeholder
     input.oninput = (e: dom.Event) => onChange
+    input.onchange = (e: dom.Event) => input.blur()
     input.disabled = disabled
     targetNode.appendChild(input)
     input

--- a/src/main/scala/document.scala
+++ b/src/main/scala/document.scala
@@ -65,7 +65,12 @@ object Document:
   def appendHomeLink(targetNode: dom.Node) =
     Document.appendLinkToApp(targetNode, Muntabot, "Tillbaka hem")
 
-  def setupContainer(
+  /** Deletes the element with the same id from the targetNode if it exists, and
+    * then creates a new 'div' element and returns it.
+    *
+    * The default targetNode is the document body.
+    */
+  def appendDynamicContainer(
       id: String = "container",
       targetNode: dom.Node = document.body
   ): dom.Element =
@@ -79,6 +84,6 @@ object Document:
     containerElement
 
   def pageNotFound(): Unit =
-    val containerElement = setupContainer()
+    val containerElement = appendDynamicContainer()
     appendHomeLink(containerElement)
     appendText(containerElement, "h1", "Oops! Page not found.")

--- a/src/main/scala/document.scala
+++ b/src/main/scala/document.scala
@@ -67,8 +67,9 @@ object Document:
 
   /** Deletes the element with the same id from the targetNode if it exists, and
     * then creates a new 'div' element and returns it.
-    *
-    * The default targetNode is the document body.
+    * 
+    * @param id defaults to "container"
+    * @param targetNode defaults to the document body
     */
   def appendDynamicContainer(
       id: String = "container",

--- a/src/main/scala/document.scala
+++ b/src/main/scala/document.scala
@@ -64,14 +64,17 @@ object Document:
   def appendHomeLink(targetNode: dom.Node) =
     Document.appendLinkToApp(targetNode, Muntabot, "Tillbaka hem")
 
-  def setupContainer(): dom.Element =
-    val oldContainerElement = document.getElementById("container")
+  def setupContainer(
+      id: String = "container",
+      targetNode: dom.Node = document.body
+  ): dom.Element =
+    val oldContainerElement = document.getElementById(id)
     if (oldContainerElement != null) then
-      document.body.removeChild(oldContainerElement)
+      targetNode.removeChild(oldContainerElement)
 
     val containerElement = document.createElement("div")
-    containerElement.id = "container"
-    document.body.appendChild(containerElement)
+    containerElement.id = id
+    targetNode.appendChild(containerElement)
     containerElement
 
   def pageNotFound(): Unit =


### PR DESCRIPTION
The search has a lot of bugs currently, for example if you remove what you just searched for the search input loses focus. It is also very hard to use on mobile.

These issues are caused by the fact that the entire site is re-rendered on user input (changing page (muntabot/rehearsal), view (week/category), or searching). This is fixed by adding the option to attach a targetNode to the dynamic container that is created with `appendDynamicContainer` and use different dynamic containers for different purposes. 