### PR TITLE
Scala theme CSS modifications (New)

### DIFF
--- a/public/anchor.css
+++ b/public/anchor.css
@@ -1,0 +1,26 @@
+a {
+  text-decoration: none;
+  font-weight: bold;
+  display: inline-block;
+  position: relative;
+  color: blue;
+  transition: 0.2s;
+}
+
+a::after {
+  content: "";
+  position: absolute;
+  width: 100%;
+  transform: scaleX(1);
+  height: 2px;
+  bottom: 0;
+  left: 0;
+  background-color: blue;
+  transform-origin: bottom right;
+  transition: transform 0.25s ease-out;
+}
+
+a:hover::after {
+  transform: scaleX(0);
+  transform-origin: bottom left;
+}

--- a/public/style.css
+++ b/public/style.css
@@ -12,6 +12,11 @@ body {
   padding: 1rem;
   font-size: 1.2rem;
   margin: 0;
+
+  /* Important for allowing #container to stretch to remainder of parent height */
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 input,
@@ -23,10 +28,6 @@ button {
   padding-bottom: 5px;
   margin-right: 1rem;
   margin-bottom: 1rem;
-}
-
-pre {
-  white-space: pre-line;
 }
 
 @media (max-width: 768px) {
@@ -50,6 +51,12 @@ pre {
 #container {
   width: 100%;
   overflow: hidden;
+
+  /* Important for allowing .question-box to stretch to remainder of parent height */
+  min-height: 0px;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
 }
 
 * {
@@ -66,4 +73,12 @@ pre {
   box-sizing: border-box;
   padding: 2rem;
   background-color: white;
+
+  /* Stretch to remainder of parent height */
+  min-height: 0px;
+  display: flex;
+  flex: 1;
+
+  /* Moved from "pre" selector */
+  white-space: pre-line;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -1,4 +1,5 @@
-html, body {
+html,
+body {
   background-color: pink;
   line-height: 1.2;
   font-family: "Lucida Console", Monaco, monospace;
@@ -9,7 +10,8 @@ body {
   font-size: 1.2rem;
   margin: 0;
 }
-input, button {
+input,
+button {
   font-size: 1.2rem;
   padding-right: 5px;
   padding-left: 5px;
@@ -21,17 +23,17 @@ input, button {
 pre {
   white-space: pre-line;
 }
-@media(max-width: 768px) {
+@media (max-width: 768px) {
   h1 {
     font-size: 2rem;
   }
 }
-@media(max-width: 365px) {
+@media (max-width: 365px) {
   h1 {
     font-size: 1.75rem;
   }
 }
-@media(max-width: 325px) {
+@media (max-width: 325px) {
   h1 {
     font-size: 1.5rem;
   }
@@ -47,4 +49,8 @@ pre {
 
 #page-decider {
   display: none;
+}
+
+.test {
+  color: blue;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -27,7 +27,6 @@ button {
   padding-top: 5px;
   padding-bottom: 5px;
   margin-right: 1rem;
-  margin-bottom: 1rem;
 }
 
 @media (max-width: 768px) {
@@ -66,10 +65,16 @@ button {
   display: none;
 }
 
+.button-container {
+  display: flex;
+  flex-direction: row;
+  margin: 0.5rem 0;
+}
+
 .question-box {
   border-left: 5px solid var(--scala-bright-red);
+  border-bottom-right-radius: 15px;
   box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
-  box-sizing: border-box;
   padding: 2rem;
   background-color: white;
 

--- a/public/style.css
+++ b/public/style.css
@@ -1,3 +1,5 @@
+@import "./variables.css";
+
 html,
 body {
   background-color: pink;
@@ -5,11 +7,13 @@ body {
   font-family: "Lucida Console", Monaco, monospace;
   max-width: 100vw;
 }
+
 body {
   padding: 1rem;
   font-size: 1.2rem;
   margin: 0;
 }
+
 input,
 button {
   font-size: 1.2rem;
@@ -20,24 +24,29 @@ button {
   margin-right: 1rem;
   margin-bottom: 1rem;
 }
+
 pre {
   white-space: pre-line;
 }
+
 @media (max-width: 768px) {
   h1 {
     font-size: 2rem;
   }
 }
+
 @media (max-width: 365px) {
   h1 {
     font-size: 1.75rem;
   }
 }
+
 @media (max-width: 325px) {
   h1 {
     font-size: 1.5rem;
   }
 }
+
 #container {
   width: 100%;
   overflow: hidden;
@@ -51,6 +60,10 @@ pre {
   display: none;
 }
 
-.test {
-  color: blue;
+.question-box {
+  border-left: 5px solid var(--scala-bright-red);
+  box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
+  box-sizing: border-box;
+  padding: 2rem;
+  background-color: white;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -1,4 +1,5 @@
 @import "./variables.css";
+@import "./anchor.css";
 
 html,
 body {
@@ -69,6 +70,27 @@ button {
   display: flex;
   flex-direction: row;
   margin: 0.5rem 0;
+}
+
+.button-container button {
+  /* Removing default button CSS properties */
+  outline: none;
+  border: none;
+  border-radius: 0;
+
+  /* Applying own CSS properties */
+  background-color: var(--scala-bright-red);
+  color: white;
+  padding: 0.75rem 1.2rem;
+  cursor: pointer;
+  box-shadow: rgba(255, 255, 255, 0.1) 0px 1px 1px 0px inset,
+    rgba(50, 50, 93, 0.25) 0px 50px 100px -20px,
+    rgba(0, 0, 0, 0.3) 0px 30px 60px -30px;
+  transition: 0.1s;
+}
+
+.button-container button:hover {
+  background-color: var(--scala-dark-red);
 }
 
 .question-box {

--- a/public/style.css
+++ b/public/style.css
@@ -9,7 +9,7 @@ body {
 }
 
 body {
-  padding: 1rem;
+  padding: 2rem;
   font-size: 1.2rem;
   margin: 0;
 
@@ -50,7 +50,6 @@ button {
 
 #container {
   width: 100%;
-  overflow: hidden;
 
   /* Important for allowing .question-box to stretch to remainder of parent height */
   min-height: 0px;

--- a/public/variables.css
+++ b/public/variables.css
@@ -1,4 +1,4 @@
 :root {
   --scala-bright-red: #de3423;
-  --scala-dark-red: #380d09;
+  --scala-dark-red: #7b1c14;
 }

--- a/public/variables.css
+++ b/public/variables.css
@@ -1,0 +1,4 @@
+:root {
+  --scala-bright-red: #de3423;
+  --scala-dark-red: #380d09;
+}

--- a/src/main/scala/apps/muntabot.scala
+++ b/src/main/scala/apps/muntabot.scala
@@ -25,10 +25,16 @@ object Muntabot extends App:
     showText.className = "question-box"
     showText.textContent = "Klicka på knapparna så får du en uppgift."
 
+    // Own container for the buttons since they should have default flex-direction
+    val buttonContainer =
+      document.createElement("div").asInstanceOf[dom.html.Div]
+
     for questionType <- Questions.types do
-      Document.appendButton(containerElement, questionType.title) {
+      Document.appendButton(buttonContainer, questionType.title) {
         showText.textContent =
           questionType.getQuestion(questionType.pickAnyQuestion)
       }
+
+    containerElement.appendChild(buttonContainer)
 
     containerElement.appendChild(showText)

--- a/src/main/scala/apps/muntabot.scala
+++ b/src/main/scala/apps/muntabot.scala
@@ -28,6 +28,7 @@ object Muntabot extends App:
     // Own container for the buttons since they should have default flex-direction
     val buttonContainer =
       document.createElement("div").asInstanceOf[dom.html.Div]
+    buttonContainer.className = "button-container"
 
     for questionType <- Questions.types do
       Document.appendButton(buttonContainer, questionType.title) {

--- a/src/main/scala/apps/muntabot.scala
+++ b/src/main/scala/apps/muntabot.scala
@@ -18,11 +18,11 @@ object Muntabot extends App:
     )
 
     val p = dom.document.createElement("p").asInstanceOf[dom.html.Element]
-    p.textContent = "adbiod: papper, penna, REPL, snabbreferens."
-    p.className = "test"
+    p.textContent = "Hjälpmedel: papper, penna, REPL, snabbreferens."
     containerElement.appendChild(p)
 
     val showText = document.createElement("pre").asInstanceOf[dom.html.Pre]
+    showText.className = "question-box"
     showText.textContent = "Klicka på knapparna så får du en uppgift."
 
     for questionType <- Questions.types do

--- a/src/main/scala/apps/muntabot.scala
+++ b/src/main/scala/apps/muntabot.scala
@@ -17,16 +17,10 @@ object Muntabot extends App:
       "Alla frågor"
     )
 
-    Document.appendText(
-      containerElement,
-      "p",
-      "Hjälpmedel: papper, penna, REPL, snabbreferens."
-    )
-    Document.appendText(
-      containerElement,
-      "p",
-      "Alla labbbar ska vara godkända innan muntliga provet."
-    )
+    val p = dom.document.createElement("p").asInstanceOf[dom.html.Element]
+    p.textContent = "adbiod: papper, penna, REPL, snabbreferens."
+    p.className = "test"
+    containerElement.appendChild(p)
 
     val showText = document.createElement("pre").asInstanceOf[dom.html.Pre]
     showText.textContent = "Klicka på knapparna så får du en uppgift."


### PR DESCRIPTION
[Old PR](https://github.com/bjornregnell/muntabot/pull/8), which I closed due to realizing that many fundamental changes could be made in smarter ways, which is what I've done in this PR.

## Description
Modified CSS to align its appearance more closely with the Scala language aesthetic. Apart from `button` and `anchor tag` styling, minor structural DOM changes have been made in order to allow the `pre` element to stretch to remainder of body height. 

## Showcase
### Muntabot *before* changes
![image](https://github.com/bjornregnell/muntabot/assets/93473565/d297136e-7f79-45f0-a23a-e82c96025b04)

### Muntabot *after* changes
![image](https://github.com/bjornregnell/muntabot/assets/93473565/e64dae5d-c0d2-4b53-8258-857c7ca05db1)

## Other notes
- After previous discussions in the old PR, I tested the page for errors relating to color-blindness accessibility through the Accessibility tab in the Firefox inspect tool, and found no problems. 